### PR TITLE
RP2040 example

### DIFF
--- a/examples/LoRaWAN_RP2040/LoRaWAN_RP2040.ino
+++ b/examples/LoRaWAN_RP2040/LoRaWAN_RP2040.ino
@@ -1,0 +1,205 @@
+/*
+
+This demonstrates how to save the join information in to permanent memory
+so that if the power fails, batteries run out or are changed, the rejoin
+is more efficient & happens sooner due to the way that LoRaWAN secures
+the join process - see the wiki for more details.
+
+This is typically useful for devices that need more power than a battery
+driven sensor - something like a air quality monitor or GPS based device that
+is likely to use up it's power source resulting in loss of the session.
+
+The relevant code is flagged with a ##### comment
+
+Saving the entire session is possible but not demonstrated here - it has
+implications for flash wearing and complications with which parts of the 
+session may have changed after an uplink. So it is assumed that the device
+is going in to deep-sleep, as below, between normal uplinks.
+
+Configure Flash Size to provide a file system (FS)! (64KB is sufficient)
+*/
+
+#if !defined(ARDUINO_ARCH_RP2040)
+  #pragma error ("This is not the example your device is looking for - RP2040 only")
+#endif
+
+#include "src/rp2040/pico_rtc_utils.h"
+
+// ##### load the preferences facilites (https://github.com/vshymanskyy/Preferences)
+#include <Preferences.h>
+Preferences store;
+
+// LoRaWAN config, credentials & pinmap
+#include "config.h" 
+
+#include <RadioLib.h>
+
+// Utilities & vars to support deep-sleep. Putting values into the .uninitialized_data
+// section prevents that those values are changed after soft reset.
+// This means normal initialization won't work.
+// As a workaround, we use the watchdog scratch register 1 to store bootCount, which is reset to 0
+// by HW and maintains its value after a SW reset.
+uint16_t bootCount;
+uint16_t bootCountSinceUnsuccessfulJoin __attribute__((section(".uninitialized_data"))); // init 0
+uint8_t LWsession[RADIOLIB_LORAWAN_SESSION_BUF_SIZE] __attribute__((section(".uninitialized_data")));
+
+
+// Sleep for <seconds>
+// Note:
+// RP2040 RTC wake-up is triggered when the programmed time and date is reached.
+// Please not that the RP2040 RTC is reset even by a soft reset! (sic!)
+void gotoSleep(uint32_t seconds)
+{
+  watchdog_hw->scratch[1] = bootCount;
+  Serial.print(F("Sleeping for "));
+  Serial.print(seconds);
+  Serial.println(F(" seconds"));
+  time_t t_now = 0;
+  datetime_t dt;
+  epoch_to_datetime(&t_now, &dt);
+  rtc_set_datetime(&dt);
+  delay(100);
+  pico_sleep(seconds);
+}
+
+// setup ...
+void setup() {
+  Serial.begin(115200);
+  while (!Serial);  							// wait for serial to be initalised
+  delay(2000);  									// give time to switch to the serial monitor
+  Serial.println(F("\nSetup"));
+  
+  // see pico-sdk/src/rp2_common/hardware_rtc/rtc.c
+  rtc_init();
+  sleep_us(64);
+
+  bootCount = watchdog_hw->scratch[1];
+  if (bootCount == 0) {
+    // HW reset occurred, initialize variables in .uninitialized_data section
+    bootCount = 1;
+    bootCountSinceUnsuccessfulJoin = 0;
+    
+    // Note: LWsession does not require initialization
+  }
+
+  int16_t state = 0;  						// return value for calls to RadioLib
+
+  // setup the radio based on the pinmap (connections) in config.h
+  Serial.println(F("Initalise the radio"));
+  state = radio.begin();
+  debug(state != RADIOLIB_ERR_NONE, F("Initalise radio failed"), state, true);
+
+  Serial.println(F("Recalling LoRaWAN nonces & session"));
+  // ##### setup the flash storage
+  store.begin("radiolib");
+  // ##### if we have previously saved nonces, restore them
+  if (store.isKey("nonces")) {
+    uint8_t buffer[RADIOLIB_LORAWAN_NONCES_BUF_SIZE];										// create somewhere to store nonces
+    store.getBytes("nonces", buffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);	// get them to the store
+    state = node.setBufferNonces(buffer); 															// send them to LoRaWAN
+    debug(state != RADIOLIB_ERR_NONE, F("Restoring nonces buffer failed"), state, false);
+  }
+
+  // recall session from RAM deep-sleep preserved variable
+  state = node.setBufferSession(LWsession); // send them to LoRaWAN stack
+  // if we have booted at least once we should have a session to restore, so report any failure
+  // otherwise no point saying there's been a failure when it was bound to fail with an empty 
+  // LWsession var. At this point, bootCount has already been incremented, hence the > 2
+  debug((state != RADIOLIB_ERR_NONE) && (bootCount > 2), F("Restoring session buffer failed"), state, false);
+
+  // process the restored session or failing that, create a new one & 
+  // return flag to indicate a fresh join is required
+  Serial.println(F("Setup LoRaWAN session"));
+  state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, false);
+  // see comment above, no need to report a failure that is bound to occur on first boot
+  debug((state != RADIOLIB_ERR_NONE) && (bootCount > 2), F("Restore session failed"), state, false);
+
+  // loop until successful join
+  while (state != RADIOLIB_ERR_NONE) {
+    Serial.println(F("Join ('login') to the LoRaWAN Network"));
+    state = node.beginOTAA(joinEUI, devEUI, nwkKey, appKey, true);
+
+    if (state < RADIOLIB_ERR_NONE) {
+      Serial.print(F("Join failed: "));
+      Serial.println(state);
+
+      // how long to wait before join attempts. This is an interim solution pending 
+      // implementation of TS001 LoRaWAN Specification section #7 - this doc applies to v1.0.4 & v1.1
+      // it sleeps for longer & longer durations to give time for any gateway issues to resolve
+      // or whatever is interfering with the device <-> gateway airwaves.
+      uint32_t sleepForSeconds = min((bootCountSinceUnsuccessfulJoin++ + 1UL) * 60UL, 3UL * 60UL);
+      Serial.print(F("Boots since unsuccessful join: "));
+      Serial.println(bootCountSinceUnsuccessfulJoin);
+      Serial.print(F("Retrying join in "));
+      Serial.print(sleepForSeconds);
+      Serial.println(F(" seconds"));
+
+      gotoSleep(sleepForSeconds);
+
+    } else {  // join was successful
+        Serial.println(F("Joined"));
+
+        // ##### save the join counters (nonces) to permanent store
+        Serial.println(F("Saving nonces to flash"));
+        uint8_t buffer[RADIOLIB_LORAWAN_NONCES_BUF_SIZE];           // create somewhere to store nonces
+        uint8_t *persist = node.getBufferNonces();                  // get pointer to nonces
+        memcpy(buffer, persist, RADIOLIB_LORAWAN_NONCES_BUF_SIZE);  // copy in to buffer
+        store.putBytes("nonces", buffer, RADIOLIB_LORAWAN_NONCES_BUF_SIZE); // send them to the store
+
+        // we'll save the session after the uplink
+
+        // reset the failed join count
+        bootCountSinceUnsuccessfulJoin = 0;
+
+        delay(1000);  // hold off off hitting the airwaves again too soon - an issue in the US
+
+    } // if beginOTAA state
+  } // while join
+
+  // ##### close the store
+  store.end();  
+  
+
+  // ----- and now for the main event -----
+  Serial.println(F("Sending uplink"));
+
+  // build payload byte array
+  uint8_t uplinkPayload[4];
+  uplinkPayload[0] = 0xDE;
+  uplinkPayload[1] = 0xAD;
+  uplinkPayload[2] = 0xBE;
+  uplinkPayload[3] = 0xEF;
+  
+  // perform an uplink
+  state = node.sendReceive(uplinkPayload, sizeof(uplinkPayload));    
+  debug((state != RADIOLIB_LORAWAN_NO_DOWNLINK) && (state != RADIOLIB_ERR_NONE), F("Error in sendReceive"), state, false);
+
+  Serial.print(F("FcntUp: "));
+  Serial.println(node.getFcntUp());
+
+  // now save session to RTC memory
+  uint8_t *persist = node.getBufferSession();
+  memcpy(LWsession, persist, RADIOLIB_LORAWAN_SESSION_BUF_SIZE);
+  
+  // wait until next uplink - observing legal & TTN FUP constraints
+  gotoSleep(uplinkIntervalSeconds);
+
+  // --------------------------------------------------------------------------
+  // The RP2040 is actually capable of resuming normal operation after wake-up,
+  // so the main part of the sketch could be executed in loop().
+  // Unfortunately, the correct way to restore the clocks after wake-up still
+  // has to be found.
+  // --------------------------------------------------------------------------
+
+  // Soft reset
+  rp2040.restart();
+}
+
+
+// The RP2040 wakes from deep-sleep and executes a soft reset - this mimics
+// the ESP32's behavior.
+// It then goes back to sleep, so loop() is never called and which is
+// why it is empty.
+void loop() {
+
+}

--- a/examples/LoRaWAN_RP2040/config.h
+++ b/examples/LoRaWAN_RP2040/config.h
@@ -2,10 +2,9 @@
 #define _CONFIG_H
 
 #include <RadioLib.h>
-#include "secrets.h"
 
 // How often to send an uplink - consider legal & FUP constraints - see notes
-const uint32_t uplinkIntervalSeconds = 1UL * 60UL;    // minutes x seconds
+const uint32_t uplinkIntervalSeconds = 5UL * 60UL;    // minutes x seconds
 
 // JoinEUI - previous versions of LoRaWAN called this AppEUI
 // for development purposes you can use all zeros - see wiki for details

--- a/examples/LoRaWAN_RP2040/config.h
+++ b/examples/LoRaWAN_RP2040/config.h
@@ -1,0 +1,140 @@
+#ifndef _CONFIG_H
+#define _CONFIG_H
+
+#include <RadioLib.h>
+#include "secrets.h"
+
+// How often to send an uplink - consider legal & FUP constraints - see notes
+const uint32_t uplinkIntervalSeconds = 1UL * 60UL;    // minutes x seconds
+
+// JoinEUI - previous versions of LoRaWAN called this AppEUI
+// for development purposes you can use all zeros - see wiki for details
+#define RADIOLIB_LORAWAN_JOIN_EUI  0x0000000000000000
+
+// The Device EUI & two keys can be generated on the TTN console 
+#ifndef RADIOLIB_LORAWAN_DEV_EUI   // Replace with your Device EUI
+#define RADIOLIB_LORAWAN_DEV_EUI   0x---------------
+#endif
+#ifndef RADIOLIB_LORAWAN_APP_KEY   // Replace with your App Key 
+#define RADIOLIB_LORAWAN_APP_KEY   0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x-- 
+#endif
+#ifndef RADIOLIB_LORAWAN_NWK_KEY   // Put your Nwk Key here
+#define RADIOLIB_LORAWAN_NWK_KEY   0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x--, 0x-- 
+#endif
+
+// For the curious, the #ifndef blocks allow for automated testing &/or you can
+// put your EUI & keys in to your platformio.ini - see wiki for more tips
+
+
+
+// Regional choices: EU868, US915, AU915, AS923, IN865, KR920, CN780, CN500
+const LoRaWANBand_t Region = EU868;
+const uint8_t subBand = 0;  // For US915, change this to 2, otherwise leave on 0
+
+
+// ============================================================================
+// Below is to support the sketch - only make changes if the notes say so ...
+
+// Auto select MCU <-> radio connections
+// If you get an error message when compiling, it may be that the 
+// pinmap could not be determined - see the notes for more info
+
+// Adafruit
+#if defined(ARDUINO_SAMD_FEATHER_M0)
+    #pragma message ("Adafruit Feather M0 with RFM95")
+    #pragma message ("Link required on board")
+    SX1276 radio = new Module(8, 3, 4, 6);
+
+
+// LilyGo 
+#elif defined(ARDUINO_TTGO_LORA32_V1)
+  #pragma message ("TTGO LoRa32 v1 - no Display")
+  SX1276 radio = new Module(18, 26, 14, 33);
+
+#elif defined(ARDUINO_TTGO_LORA32_V2)
+   #pragma error ("ARDUINO_TTGO_LORA32_V2 awaiting pin map")
+
+#elif defined(ARDUINO_TTGO_LoRa32_v21new) // T3_V1.6.1
+  #pragma message ("Using TTGO LoRa32 v2.1 marked T3_V1.6.1 + Display")
+  SX1276 radio = new Module(18, 26, 14, 33);
+
+#elif defined(ARDUINO_TBEAM_USE_RADIO_SX1262)
+  #pragma error ("ARDUINO_TBEAM_USE_RADIO_SX1262 awaiting pin map")
+
+#elif defined(ARDUINO_TBEAM_USE_RADIO_SX1276)
+  #pragma message ("Using TTGO LoRa32 v2.1 marked T3_V1.6.1 + Display")
+  SX1276 radio = new Module(18, 26, 23, 33);
+
+
+// Heltec
+#elif defined(ARDUINO_HELTEC_WIFI_LORA_32)
+  #pragma error ("ARDUINO_HELTEC_WIFI_LORA_32 awaiting pin map")
+
+#elif defined(ARDUINO_heltec_wifi_kit_32_V2)
+  #pragma message ("ARDUINO_heltec_wifi_kit_32_V2 awaiting pin map")
+  SX1276 radio = new Module(18, 26, 14, 35);
+
+#elif defined(ARDUINO_heltec_wifi_kit_32_V3)
+  #pragma message ("Using Heltec WiFi LoRa32 v3 - Display + USB-C")
+  SX1262 radio = new Module(8, 14, 12, 13);
+
+#elif defined(ARDUINO_CUBECELL_BOARD)
+  #pragma message ("Using TTGO LoRa32 v2.1 marked T3_V1.6.1 + Display")
+  SX1262 radio = new Module(RADIOLIB_BUILTIN_MODULE);
+
+#elif defined(ARDUINO_CUBECELL_BOARD_V2)
+  #pragma error ("ARDUINO_CUBECELL_BOARD_V2 awaiting pin map")
+
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  // Use pinning for Adafruit Feather RP2040 with RFM95W "FeatherWing" ADA3232
+  #define PIN_LORA_NSS      7
+  #define PIN_LORA_RST     11
+  #define PIN_LORA_IRQ     8
+  #define PIN_LORA_GPIO    10
+  #pragma message("ARDUINO_ADAFRUIT_FEATHER_RP2040 defined; assuming RFM95W FeatherWing will be used")
+  #pragma message("Required wiring: A to RST, B to DIO1, D to DIO0, E to CS")
+  SX1276 radio = new Module(7, 8, 11, 10);
+
+#else
+  #pragma message ("Unknown board - no automagic pinmap available")
+
+  // SX1262  pin order: Module(NSS/CS, DIO1, RESET, BUSY);
+  // SX1262 radio = new Module(8, 14, 12, 13);
+
+  // SX1278 pin order: Module(NSS/CS, DIO0, RESET, DIO1);
+  // SX1278 radio = new Module(10, 2, 9, 3);
+
+#endif
+
+
+// Copy over the EUI's & keys in to the something that will not compile if incorrectly formatted
+uint64_t joinEUI =   RADIOLIB_LORAWAN_JOIN_EUI;
+uint64_t devEUI  =   RADIOLIB_LORAWAN_DEV_EUI;
+uint8_t appKey[] = { RADIOLIB_LORAWAN_APP_KEY };
+uint8_t nwkKey[] = { RADIOLIB_LORAWAN_NWK_KEY };
+
+// Create the LoRaWAN node
+LoRaWANNode node(&radio, &Region, subBand);
+
+
+// Helper function to display any issues
+void debug(bool isFail, const __FlashStringHelper* message, int state, bool Freeze) {
+  if (isFail) {
+    Serial.print(message);
+    Serial.print("(");
+    Serial.print(state);
+    Serial.println(")");
+    while (Freeze);
+  }
+}
+
+// Helper function to display a byte array
+void arrayDump(uint8_t *buffer, uint16_t len) {
+  for (uint16_t c = 0; c < len; c++) {
+    Serial.printf("%02X", buffer[c]);
+  }
+  Serial.println();
+}
+
+
+#endif

--- a/examples/LoRaWAN_RP2040/notes.md
+++ b/examples/LoRaWAN_RP2040/notes.md
@@ -1,0 +1,199 @@
+
+
+# RadioLib LoRaWAN on TTN starter script
+
+## Welcome
+
+These notes are for someone who has successfully created a few sketches for their Arduino based device but is starting out with LoRaWAN. You don't have to be a C coding ninja but some familarity with C and procedural programming is assumed. The absolutely simplest way to get started is to buy some known good hardware that's all done for you so you can concentrate on the code & configuration.
+
+
+## Introduction
+
+LoRaWAN is an amazing system for small battery powered sensors collecting data for years at a time. With great features comes some more complex elements which means it is not quite as simple as just providing WiFi credentials and pushing data through. It is in the range of setting up & customising the settings for a home router but with no wizards to do the heavy lifting for you. So we strongly recommend spending a couple of hours reviewing the TTN Getting Started section so you are aware of the minimum knowledge to make a successful start: https://www.thethingsnetwork.org/docs/lorawan/. Johan's video is amazing but is also drinking from the firehose. Read the text first and then watch the video on Youtube where there are bookmarks to deliver it in small digestable chunks.
+
+These notes plus a lot more are available in the wiki: https://github.com/jgromes/RadioLib/wiki/LoRaWAN
+
+For questions about using RadioLib there is the discussions section (https://github.com/jgromes/RadioLib/discussions) and if you believe you've found an issue (aka bug), the issues section (https://github.com/jgromes/RadioLib/issues). If posting an issue please ensure you tell us what hardware you are using and provide a debug log - please do not use verbose mode unless asked to. If the question is more LoRaWAN or firmware related, then you can use the TTN forum: https://www.thethingsnetwork.org/forum/
+
+
+## Register & setup on TTN
+
+This sketch isn't particularly aimed at The Things Stack (TTS) but you can get a free Sandbox account and the following instructions are for that. Helium does not support LoRaWAN v1.1 which is the version implemented by RadioLib. Chirpstack & other LoRaWAN Network Server (LNS) stacks have not yet been tried so YMMV.
+
+Why no screen shots? TTS is a web based app, one that you will need to become familiar with and we will need to direct you to some of the less obvious parts. So much better that you learn the layouts in concept than slavishly follow screen shots that can & will go stale.
+
+There will be some instructions that you have to take on face value. You didn't learn to run before you walked and it's so much more encouraging to get started and build on success than get bogged down in endless details. Once you are up & running more of the details start to slot in to place.
+
+### Register on TTN
+
+Go to https://www.thethingsnetwork.org/get-started and register - just like any other website. These instructions are for TTS Sandbox.
+
+Once you have confirmed your email address, you can login to the console here: https://console.cloud.thethings.network/. If you allow your browser to share you location the best console will be selected. For most users the best one is the obvious one, if you have any doubts you can ask on the forum here: https://www.thethingsnetwork.org/forum/ - you login with the exact same details.
+
+It is simpler to register your gateway first. If you don't have a gateway, then a The Things Indoor Gateway (TTIG) is a very affordable option. A gateway gives you a console to see if your device is being heard and is hugely useful when debugging a DIY device. If you are in range of a community gateway you may be lucky with your first device creation but you will never know if you are in range unless you have access to that gateways console.
+
+You can read up on key concepts and troubleshooting here: https://www.thethingsindustries.com/docs/gateways/
+
+LoRa stands for Long Range - having the gateway & device on the same desk tends to overload both receiver circuits when they hear a transmission so close to hand. The gateway should be 5 - 10m away, preferably with a solid wall in the way as well.
+
+### Create your application
+
+An application is like a box to keep some devices in - normally doing the same thing - on larger deployments this may be 1,000's of similar devices. Starting out it is likely to be just a few so there is no need to get concerned about how to divide up your use just yet.
+
+Onced logged in to the console you can go in to Applications to create your first application. The ID must be all lower case or numbers, no spaces, dashes are OK and it has to be unique to the entire TTN community - so `first-app` will be rejected - you could use `your-username-first-app` as that's likely to be unique. The name and description are for your own use and are optional.
+
+The main menu for an application is in the left hand panel - nothing is needed there just yet.
+
+### Create your device
+
+On the right hand side about half way down on your application's summary is a big blue button `+ Register end device`. Click this to create the settings for your first device.
+
+You are making your own device using a third party LoRaWAN stack so there will not be an entry in the device repository so choose 'Enter end device specifics manually'.
+
+Choose the Frequency plan appropriate for your region. Consider that almost all countries have laws relating to what frequencies you use so don't get creative. For Europe please use the recommended option. For other regions use the entry marked 'used by TTN'.
+
+Choose LoRaWAN 1.1.0 - the last one in the list - the latest specification. RadioLib uses RP001 Regional Parameters 1.1 revision A.
+
+At this point you will be asked for your JoinEUI. As this is a DIY device and we are using RadioLib, you can use all zero's as recommended by The LoRa Alliance TR007 Technical Recommendations document. Once you've put in all zeros and clicked confirm you will be asked for a DevEUI, AppKey and NwkKey. It is preferable to have the console generate them so they are properly formatted.
+
+Your End device ID can be changed to make the device more identifiable. Something related to your hardware helps - like devicename-01. The you can click the blue 'Register device'.
+
+When many sensors are big deployed, a device is registered, batteries put in, it joins and gets on with sending data for the next few years. For development purposes we need to turn off one of the security settings so that you can join & uplink out of the normal sequence that a device in the field would do.
+
+You then need to copy over the device details in to the config file for RadioLib. There are buttons to copy items to the clipboard so you don't have to hand type them.
+
+### Copy & Paste made easy
+
+You can copy the EUIs & keys from the device overview section.
+
+The EUIs are really straightforward - click the clipboard icon at the right hand end of the EUI display field and it will be copied in the format you need. You can then paste it in to the code - you must leave the 0x in place so the compiler knows that it's a hex value.
+
+The keys are relatively straightforward. Click the eye icon at the right hand end of the field. Then click the <> icon that will appear to the left. This will format the hex values as an array. Then you can click the clipboard icon to copy the array and then paste it between the { } brackets.
+
+### Secrets to keep safe.
+
+The Join & Dev EUI's are transmitted in plain text when the device joins a network. The gateway ID is public. If you have an issue and are asked for details, there are only three things to keep private - your password, the keys which are used for encryption and any API keys you create which are used for accessing your data & configuration.
+
+
+### Monitoring your device
+
+If you are on your application summary page you'll see uplinks in the small activity box top right with a link to the full size table. If you click the Live Data menu item on the left it will show activity for all the devices registered on the application in the full window.
+
+If you just want your devices activity, from the summary page click on the device in the list in the middle of the page.
+
+The main menu for a device is the horizontal band: Overview, Live Data, Messaging etc. You can click Live Data or the link above the small activity box.
+
+**The console shows LIVE data - not a history of everything that has ever happened. A LNS is a management & relay service, not a database. When you open the console you may see a summary of recent activity - this is a bonus. You must leave the console open, even in another tab, if you want to see live activity.**
+
+
+### Explore
+
+Nothing on the console can be upset unless you confirm a warning message, so you are safe to explore the different menus to orientate yourself. This is very good idea so you are have an understanding of the layout of the land and shouldn't take more than 10 or 15 minutes. The documentation & volunteers on GitHub and the TTN forum will make refer to parts of the console without giving blow by blow directions.
+
+
+
+
+## The config.h
+
+### The uplinkInterval
+
+LoRaWAN devices typically send small amounts of data at intervals between 15 minutes through to once per day. This allows a device to run on two AA batteries for 2 to 5 years. Hoping that LoRaWAN can move lots of data and your device can regularly receive commands to do something on demand is trying to bend the LoRaWAN system in ways it is not designed for and usually ends up with far too many issues to unravel.
+
+The radio frequencies that are used are usually shared with other Industrial, Scientific & Medical, known as ISM, users. The LoRa modulation is particularly resistance to interference due to other simultaneous transmissions on the same frequency but too much local activity will mean that not all uplinks get through. The Things Industries suggest designing a system to a potential packet loss rate of 10%. Typically we see 1 or 2% loss. This is entirely down to shared use of the radio waves, once an uplink is heard by a gateway the system is super reliable through The Things Stack.
+
+To ensure that the shared ISM bands are fairly used there are limits defined in law on how often you can transmit, called Duty Cycle. The details vary by region or country but typically you can only transmit for 1% of the time. Some frequencies you can only use 0.1% of the time. See https://www.thethingsnetwork.org/docs/lorawan/duty-cycle/ for more information.
+
+Additionally, as The Things Stack Sandbox aka TTN is an array of servers in three locations around the world paid for by The Things Industries, there is a Fair Use Policy so that those learning LoRaWAN, communities, hobbyists & makers are guided on how much of the resource any one device can use. In short, it's 30 seconds of airtime a day and 10 downlinks. When a gateway is transmitting a downlink it can not hear any uplinks (contributing to the potential uplink loss outlined above). The community concensus is that 1 downlink a fortnight to update or adjust settings is appropriate. See https://www.thethingsnetwork.org/docs/lorawan/duty-cycle/#fair-use-policy for more information.
+
+You can see what intervals can be used with this interactive calculator: https://avbentem.github.io/airtime-calculator/ttn/. Devices further away from gateways will have to use a higher Spread Factor to be heard - do not assume everything will happen at SF7. A uplink takes a minimum of 6 seconds from start to end, sometimes longer if the device is further away from the gateway, so 
+
+With all thes considerations, trying to use LoRaWAN for command & control isn't appropriate and realtime GPS tracking almost always breaches FUP and usually legal limits, leaving aside the challenges of coverage.
+
+See the hints & tips section on testing your device.
+
+
+### EUI's & Keys
+
+In the config.h towards the top there are four lines thus:
+
+// replace-with-your-device-id
+uint64_t joinEUI =   0x0000000000000000;
+uint64_t devEUI  =   0x0000000000000000;
+uint8_t appKey[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+uint8_t nwkKey[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+On the TTN console on the device summary page, click the clipboard icon next to the DevEUI, highlight the 16 0's in the third line after the x and paste.
+
+The devEUI must start with 0x and will end up looking something like 0x70B3D57ED006544E
+
+For the appKey we need TTN to format it correctly. Click the eye icon and an extra icon will appear <> - click this and the key will be formatted for you. Click the clipboard icon and then paste over the 32 0x00's in the config file. Then do the same for nwkKey.
+
+A key will end up something like 0x31, 0x16, 0x6A, 0x22, 0x97, 0x52, 0xB6, 0x34, 0x57, 0x45, 0x1B, 0xC3, 0xC9, 0xD8, 0x83, 0xE8
+
+
+### Region
+
+The region value you use MUST match the one you selected on the console. 
+
+If you are using US915 or AU915 then you should change the subBand const to 2.
+
+### The pinmap
+
+This is the connections between the MCU (ESP32/ATmega/SAMD) and the LoRa radio (SX1276/SX1262).
+
+Prebuilt modules are easy - we can detect the board and setup the pinmap for you. These boards are:
+
+* TTGO_LoRa32
+* TTGO_LoRa32_V1
+* TTGO_LORA32_V2
+* TTGO_LORA32_v21NEW
+* HELTEC_WIFI_LORA_32
+* HELTEC_WIFI_LORA_32_V2
+* HELTEC_WIFI_LORA_32_V3
+* CUBECELL_BOARD
+
+If you have a TTGO T-Beam, you must choose the correct radio from the Board Revision sub-menu found under the main Tools menu.
+
+* TBEAM_USE_RADIO_SX1262
+* TBEAM_USE_RADIO_SX1276
+
+If you have an Adafruit Feather M0 with RFM95 then you must solder a wire or use a jumper to link from pin 6 to io1: https://learn.adafruit.com/the-things-network-for-feather/arduino-wiring
+
+
+If you have a module that's not on this list, please go to the "Pinmap How-To" below.
+
+
+
+## Observations on the main sketch
+
+Most of the sketch has comments that tell you what the various parts are doing. This should add a little more info:
+
+### The Join
+
+When a device is first started, it needs to register with the LoRaWAN Network Server (LNS) and setup it's session. With the settings from the console copied over and a gateway an appropriate distance away, most of the time the join will 'just work'.
+
+If it doesn't, then there is no point trying repeatedly without going through the troubleshootng sequence. So this starter sketch will try once only to save the airwaves & TTN Community servers from repeated misfires.
+
+
+### The payload
+
+You may see other starter sketches sending text. Apart from being massively inefficient, the text isn't easily displayed on the TTN console which makes it rather pointless and pro embedded engineers don't send strings. So this sketch sends the data as a sequence of bytes as recommended.
+
+Further reading on this can be found here, just ignore the pink message about v2, it's all still valid: https://www.thethingsnetwork.org/docs/devices/bytes/
+
+We've not assumed anything about any sensors you have, so we are just reading a digital & an analog pin. An analog reading is typically a two byte value - an integer - this is split using the Arduino highByte & lowByte function. You'll see how we put it back together in the TTN console below.
+
+
+## TTN Console Payload Decoder
+
+Coming soon
+
+## Hints & Tips
+
+### Device testing
+
+The LoRaWAN code base works to a specification and once you are happy your device is able to join & send a few dozen uplinks, continuing to sit around waiting for an uplink to test your sensor code & payload format is a waste of your time. The solution is to write everything else in a different sketch, output the array to the serial console and then you can copy & paste the hex array in to the TTN console Payload Formatters section to test the decoding.
+
+
+## Pinmap How-To
+

--- a/examples/LoRaWAN_RP2040/src/rp2040/pico_rosc.h
+++ b/examples/LoRaWAN_RP2040/src/rp2040/pico_rosc.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#if defined(ARDUINO_ARCH_RP2040)
+
+#ifndef _HARDWARE_ROSC_H_
+#define _HARDWARE_ROSC_H_
+
+#include "pico.h"
+#include "hardware/structs/rosc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file rosc.h
+ *  \defgroup hardware_rosc hardware_rosc
+ *
+ * Ring Oscillator (ROSC) API
+ *
+ * A Ring Oscillator is an on-chip oscillator that requires no external crystal. Instead, the output is generated from a series of
+ * inverters that are chained together to create a feedback loop. RP2040 boots from the ring oscillator initially, meaning the
+ * first stages of the bootrom, including booting from SPI flash, will be clocked by the ring oscillator. If your design has a
+ * crystal oscillator, you’ll likely want to switch to this as your reference clock as soon as possible, because the frequency is
+ * more accurate than the ring oscillator.
+ */
+
+/*! \brief  Set frequency of the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ * \param code The drive strengths. See the RP2040 datasheet for information on this value.
+ */
+void rosc_set_freq(uint32_t code);
+
+/*! \brief  Set range of the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ * Frequency range. Frequencies will vary with Process, Voltage & Temperature (PVT).
+ * Clock output will not glitch when changing the range up one step at a time.
+ *
+ * \param range 0x01 Low, 0x02 Medium, 0x03 High, 0x04 Too High.
+ */
+void rosc_set_range(uint range);
+
+/*! \brief  Disable the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ */
+void rosc_disable(void);
+
+/*! \brief  Enable the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ */
+void rosc_enable(void);
+
+/*! \brief  Put Ring Oscillator in to dormant mode.
+ *  \ingroup hardware_rosc
+ *
+ * The ROSC supports a dormant mode,which stops oscillation until woken up up by an asynchronous interrupt.
+ * This can either come from the RTC, being clocked by an external clock, or a GPIO pin going high or low.
+ * If no IRQ is configured before going into dormant mode the ROSC will never restart.
+ *
+ * PLLs should be stopped before selecting dormant mode.
+ */
+void rosc_set_dormant(void);
+
+// FIXME: Add doxygen
+
+uint32_t next_rosc_code(uint32_t code);
+
+uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz);
+
+void rosc_set_div(uint32_t div);
+
+inline static void rosc_clear_bad_write(void) {
+    hw_clear_bits(&rosc_hw->status, ROSC_STATUS_BADWRITE_BITS);
+}
+
+inline static bool rosc_write_okay(void) {
+    return !(rosc_hw->status & ROSC_STATUS_BADWRITE_BITS);
+}
+
+inline static void rosc_write(io_rw_32 *addr, uint32_t value) {
+    rosc_clear_bad_write();
+    assert(rosc_write_okay());
+    *addr = value;
+    assert(rosc_write_okay());
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif /* ARDUINO_ARCH_RP2040 */

--- a/examples/LoRaWAN_RP2040/src/rp2040/pico_rtc_utils.cpp
+++ b/examples/LoRaWAN_RP2040/src/rp2040/pico_rtc_utils.cpp
@@ -1,0 +1,161 @@
+///////////////////////////////////////////////////////////////////////////////
+// pico_rtc_utils.cpp
+// 
+// RTC utility functions for RP2040
+//
+// Sleep/wakeup scheme based on
+// https://github.com/lyusupov/SoftRF/tree/master/software/firmware/source/libraries/RP2040_Sleep
+// by Linar Yusupov
+//
+// Using code from pico-extras:
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/pico_sleep/include/pico/sleep.h
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/pico_sleep/sleep.c
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/hardware_rosc/include/hardware/rosc.h
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/hardware_rosc/rosc.c
+//
+// created: 10/2023
+//
+//
+// MIT License
+//
+// Copyright (c) 2023 Matthias Prinke
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+// History:
+//
+// 20231006 Created
+//
+// ToDo:
+// - 
+//
+///////////////////////////////////////////////////////////////////////////////
+#if defined(ARDUINO_ARCH_RP2040)
+
+#include "pico_rtc_utils.h"
+
+struct tm *datetime_to_tm(datetime_t *dt, struct tm *ti)
+{
+  ti->tm_sec = dt->sec;
+  ti->tm_min = dt->min;
+  ti->tm_hour = dt->hour;
+  ti->tm_mday = dt->day;
+  ti->tm_mon = dt->month - 1;
+  ti->tm_year = dt->year - 1900;
+  ti->tm_wday = dt->dotw;
+
+  return ti;
+}
+
+datetime_t *tm_to_datetime(struct tm *ti, datetime_t *dt)
+{
+  dt->sec = ti->tm_sec;
+  dt->min = ti->tm_min;
+  dt->hour = ti->tm_hour;
+  dt->day = ti->tm_mday;
+  dt->month = ti->tm_mon + 1;
+  dt->year = ti->tm_year + 1900;
+  dt->dotw = ti->tm_wday;
+
+  return dt;
+}
+
+void print_dt(datetime_t dt) {
+    Serial.printf("%4d-%02d-%02d %02d:%02d:%02d\n", dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec);
+}
+
+void print_tm(struct tm ti) {
+    Serial.printf("%4d-%02d-%02d %02d:%02d:%02d\n", ti.tm_year+1900, ti.tm_mon+1, ti.tm_mday, ti.tm_hour, ti.tm_min, ti.tm_sec);
+}
+
+time_t datetime_to_epoch(datetime_t *dt, time_t *epoch) {
+        struct tm ti;
+        datetime_to_tm(dt, &ti);
+        
+        // Apply daylight saving time according to timezone and date
+        ti.tm_isdst = -1;
+
+        // Convert to epoch
+        time_t _epoch = mktime(&ti);
+
+        if (epoch) {
+          *epoch = _epoch;
+        }
+
+        return _epoch;
+}
+
+datetime_t *epoch_to_datetime(time_t *epoch, datetime_t *dt) {
+    struct tm ti;
+
+    // Apply daylight saving time according to timezone and date
+    ti.tm_isdst = -1;
+
+    // Convert epoch to struct tm
+    localtime_r(epoch, &ti);
+
+    // Convert struct tm to datetime_t
+    tm_to_datetime(&ti, dt);
+
+    return dt;
+}
+
+// Sleep for <duration> seconds
+void pico_sleep(unsigned duration) {
+    datetime_t dt;
+    rtc_get_datetime(&dt);
+    Serial.print(F("RTC time:"));
+    print_dt(dt);
+
+    time_t now;
+    datetime_to_epoch(&dt, &now);
+    
+    // Add sleep_duration
+    time_t wakeup = now + duration;
+
+    epoch_to_datetime(&wakeup, &dt);
+
+    Serial.print(F("Wakeup time:"));
+    print_dt(dt);
+
+    Serial.flush();
+    Serial1.end();
+    Serial2.end();
+    Serial.end();
+
+    // From
+    // https://github.com/lyusupov/SoftRF/tree/master/software/firmware/source/libraries/RP2040_Sleep
+    // also see src/pico_rtc
+    // --8<-----
+    #if defined(USE_TINYUSB)
+        // Disable USB
+        USBDevice.detach();
+    #endif /* USE_TINYUSB */
+
+    sleep_run_from_xosc();
+
+    sleep_goto_sleep_until(&dt, NULL);
+
+    // back from dormant state
+    rosc_enable();
+    clocks_init();
+    // --8<-----
+}
+#endif

--- a/examples/LoRaWAN_RP2040/src/rp2040/pico_rtc_utils.h
+++ b/examples/LoRaWAN_RP2040/src/rp2040/pico_rtc_utils.h
@@ -1,0 +1,72 @@
+///////////////////////////////////////////////////////////////////////////////
+// pico_rtc_utils.h
+// 
+// RTC utility functions for RP2040
+//
+// Sleep/wakeup scheme based on
+// https://github.com/lyusupov/SoftRF/tree/master/software/firmware/source/libraries/RP2040_Sleep
+// by Linar Yusupov
+//
+// Using code from pico-extras:
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/pico_sleep/include/pico/sleep.h
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/pico_sleep/sleep.c
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/hardware_rosc/include/hardware/rosc.h
+// https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/hardware_rosc/rosc.c
+//
+// created: 10/2023
+//
+//
+// MIT License
+//
+// Copyright (c) 2023 Matthias Prinke
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+// History:
+//
+// 20231006 Created
+//
+// ToDo:
+// - 
+//
+///////////////////////////////////////////////////////////////////////////////
+#if defined(ARDUINO_ARCH_RP2040)
+#include <Arduino.h>
+#include <time.h>
+#include <pico/stdlib.h>
+#include <hardware/rtc.h>
+#include "pico_sleep.h"
+#include "pico_rosc.h"
+
+#ifndef PICO_RTC_UTILS_H
+#define PICO_RTC_UTILS_H
+
+struct tm *datetime_to_tm(datetime_t *dt, struct tm *ti);
+datetime_t *tm_to_datetime(struct tm *ti, datetime_t *dt);
+time_t datetime_to_epoch(datetime_t *dt, time_t *epoch);
+datetime_t *epoch_to_datetime(time_t *epoch, datetime_t *dt);
+
+void print_dt(datetime_t dt);
+void print_tm(struct tm ti);
+
+void pico_sleep(unsigned duration);
+
+#endif // PICO_RTC_UTILS_H
+#endif // defined(ARDUINO_ARCH_RP2040)

--- a/examples/LoRaWAN_RP2040/src/rp2040/pico_sleep.h
+++ b/examples/LoRaWAN_RP2040/src/rp2040/pico_sleep.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#if defined(ARDUINO_ARCH_RP2040)
+
+#ifndef _PICO_SLEEP_H_
+#define _PICO_SLEEP_H_
+
+#include "pico.h"
+#include "hardware/rtc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file sleep.h
+ *  \defgroup hardware_sleep hardware_sleep
+ *
+ * Lower Power Sleep API
+ *
+ * The difference between sleep and dormant is that ALL clocks are stopped in dormant mode,
+ * until the source (either xosc or rosc) is started again by an external event.
+ * In sleep mode some clocks can be left running controlled by the SLEEP_EN registers in the clocks
+ * block. For example you could keep clk_rtc running. Some destinations (proc0 and proc1 wakeup logic)
+ * can't be stopped in sleep mode otherwise there wouldn't be enough logic to wake up again.
+ *
+ * \subsection sleep_example Example
+ * \addtogroup hardware_sleep
+ * \include hello_sleep.c
+
+ */
+typedef enum {
+    DORMANT_SOURCE_NONE,
+    DORMANT_SOURCE_XOSC,
+    DORMANT_SOURCE_ROSC
+} dormant_source_t;
+
+/*! \brief Set all clock sources to the the dormant clock source to prepare for sleep.
+ *  \ingroup hardware_sleep
+ *
+ * \param dormant_source The dormant clock source to use
+ */
+void sleep_run_from_dormant_source(dormant_source_t dormant_source);
+
+/*! \brief Set the dormant clock source to be the crystal oscillator
+ *  \ingroup hardware_sleep
+ */
+static inline void sleep_run_from_xosc(void) {
+    sleep_run_from_dormant_source(DORMANT_SOURCE_XOSC);
+}
+
+/*! \brief Set the dormant clock source to be the ring oscillator
+ *  \ingroup hardware_sleep
+ */
+static inline void sleep_run_from_rosc(void) {
+    sleep_run_from_dormant_source(DORMANT_SOURCE_ROSC);
+}
+
+/*! \brief Send system to sleep until the specified time
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param t The time to wake up
+ * \param callback Function to call on wakeup.
+ */
+void sleep_goto_sleep_until(datetime_t *t, rtc_callback_t callback);
+
+/*! \brief Send system to sleep until the specified GPIO changes
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ * \param edge true for leading edge, false for trailing edge
+ * \param high true for active high, false for active low
+ */
+void sleep_goto_dormant_until_pin(uint gpio_pin, bool edge, bool high);
+
+/*! \brief Send system to sleep until a leading high edge is detected on GPIO
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ */
+static inline void sleep_goto_dormant_until_edge_high(uint gpio_pin) {
+    sleep_goto_dormant_until_pin(gpio_pin, true, true);
+}
+
+/*! \brief Send system to sleep until a high level is detected on GPIO
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ */
+static inline void sleep_goto_dormant_until_level_high(uint gpio_pin) {
+    sleep_goto_dormant_until_pin(gpio_pin, false, true);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif /* ARDUINO_ARCH_RP2040 */

--- a/examples/LoRaWAN_RP2040/src/rp2040/rosc.c
+++ b/examples/LoRaWAN_RP2040/src/rp2040/rosc.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#if defined(ARDUINO_ARCH_RP2040)
+
+#include "pico.h"
+
+// For MHZ definitions etc
+#include "hardware/clocks.h"
+#include "pico_rosc.h"
+
+// Given a ROSC delay stage code, return the next-numerically-higher code.
+// Top result bit is set when called on maximum ROSC code.
+uint32_t next_rosc_code(uint32_t code) {
+    return ((code | 0x08888888u) + 1u) & 0xf7777777u;
+}
+
+uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz) {
+    // TODO: This could be a lot better
+    rosc_set_div(1);
+    for (uint32_t code = 0; code <= 0x77777777u; code = next_rosc_code(code)) {
+        rosc_set_freq(code);
+        uint rosc_mhz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_ROSC_CLKSRC) / 1000;
+        if ((rosc_mhz >= low_mhz) && (rosc_mhz <= high_mhz)) {
+            return rosc_mhz;
+        }
+    }
+    return 0;
+}
+
+void rosc_set_div(uint32_t div) {
+    assert(div <= 31 && div >= 1);
+    rosc_write(&rosc_hw->div, ROSC_DIV_VALUE_PASS + div);
+}
+
+void rosc_set_freq(uint32_t code) {
+    rosc_write(&rosc_hw->freqa, (ROSC_FREQA_PASSWD_VALUE_PASS << ROSC_FREQA_PASSWD_LSB) | (code & 0xffffu));
+    rosc_write(&rosc_hw->freqb, (ROSC_FREQA_PASSWD_VALUE_PASS << ROSC_FREQA_PASSWD_LSB) | (code >> 16u));
+}
+
+void rosc_set_range(uint range) {
+    // Range should use enumvals from the headers and thus have the password correct
+    rosc_write(&rosc_hw->ctrl, (ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB) | range);
+}
+
+void rosc_disable(void) {
+    uint32_t tmp = rosc_hw->ctrl;
+    tmp &= (~ROSC_CTRL_ENABLE_BITS);
+    tmp |= (ROSC_CTRL_ENABLE_VALUE_DISABLE << ROSC_CTRL_ENABLE_LSB);
+    rosc_write(&rosc_hw->ctrl, tmp);
+    // Wait for stable to go away
+    while(rosc_hw->status & ROSC_STATUS_STABLE_BITS);
+}
+
+void rosc_enable(void)
+{
+    uint32_t tmp = rosc_hw->ctrl;
+    tmp &= (~ROSC_CTRL_ENABLE_BITS);
+    tmp |= (ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB);
+    rosc_write(&rosc_hw->ctrl, tmp);
+    // Wait for stable
+    while ((rosc_hw->status & ROSC_STATUS_STABLE_BITS) != ROSC_STATUS_STABLE_BITS);
+}
+
+void rosc_set_dormant(void) {
+    // WARNING: This stops the rosc until woken up by an irq
+    rosc_write(&rosc_hw->dormant, ROSC_DORMANT_VALUE_DORMANT);
+    // Wait for it to become stable once woken up
+    while(!(rosc_hw->status & ROSC_STATUS_STABLE_BITS));
+}
+#endif /* ARDUINO_ARCH_RP2040 */

--- a/examples/LoRaWAN_RP2040/src/rp2040/sleep.c
+++ b/examples/LoRaWAN_RP2040/src/rp2040/sleep.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#if defined(ARDUINO_ARCH_RP2040)
+
+#include "pico.h"
+
+#include "pico/stdlib.h"
+#include "pico_sleep.h"
+
+#include "hardware/rtc.h"
+#include "hardware/pll.h"
+#include "hardware/clocks.h"
+#include "hardware/xosc.h"
+#include "pico_rosc.h"
+#include "hardware/regs/io_bank0.h"
+// For __wfi
+#include "hardware/sync.h"
+// For scb_hw so we can enable deep sleep
+#include "hardware/structs/scb.h"
+
+// The difference between sleep and dormant is that ALL clocks are stopped in dormant mode,
+// until the source (either xosc or rosc) is started again by an external event.
+// In sleep mode some clocks can be left running controlled by the SLEEP_EN registers in the clocks
+// block. For example you could keep clk_rtc running. Some destinations (proc0 and proc1 wakeup logic)
+// can't be stopped in sleep mode otherwise there wouldn't be enough logic to wake up again.
+
+
+// TODO: Optionally, memories can also be powered down.
+
+static dormant_source_t _dormant_source;
+
+bool dormant_source_valid(dormant_source_t dormant_source) {
+    return (dormant_source == DORMANT_SOURCE_XOSC) || (dormant_source == DORMANT_SOURCE_ROSC);
+}
+
+// In order to go into dormant mode we need to be running from a stoppable clock source:
+// either the xosc or rosc with no PLLs running. This means we disable the USB and ADC clocks
+// and all PLLs
+void sleep_run_from_dormant_source(dormant_source_t dormant_source) {
+    assert(dormant_source_valid(dormant_source));
+    _dormant_source = dormant_source;
+
+    // FIXME: Just defining average rosc freq here.
+    uint src_hz = (dormant_source == DORMANT_SOURCE_XOSC) ? XOSC_MHZ * MHZ : 6.5 * MHZ;
+    uint clk_ref_src = (dormant_source == DORMANT_SOURCE_XOSC) ?
+                       CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC :
+                       CLOCKS_CLK_REF_CTRL_SRC_VALUE_ROSC_CLKSRC_PH;
+
+    // CLK_REF = XOSC or ROSC
+    clock_configure(clk_ref,
+                    clk_ref_src,
+                    0, // No aux mux
+                    src_hz,
+                    src_hz);
+
+    // CLK SYS = CLK_REF
+    clock_configure(clk_sys,
+                    CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLK_REF,
+                    0, // Using glitchless mux
+                    src_hz,
+                    src_hz);
+
+    // CLK USB = 0MHz
+    clock_stop(clk_usb);
+
+    // CLK ADC = 0MHz
+    clock_stop(clk_adc);
+
+    // CLK RTC = ideally XOSC (12MHz) / 256 = 46875Hz but could be rosc
+    uint clk_rtc_src = (dormant_source == DORMANT_SOURCE_XOSC) ? 
+                       CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_XOSC_CLKSRC : 
+                       CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_ROSC_CLKSRC_PH;
+
+    clock_configure(clk_rtc,
+                    0, // No GLMUX
+                    clk_rtc_src,
+                    src_hz,
+                    46875);
+
+    // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
+    clock_configure(clk_peri,
+                    0,
+                    CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS,
+                    src_hz,
+                    src_hz);
+
+    pll_deinit(pll_sys);
+    pll_deinit(pll_usb);
+
+    // Assuming both xosc and rosc are running at the moment
+    if (dormant_source == DORMANT_SOURCE_XOSC) {
+        // Can disable rosc
+        rosc_disable();
+    } else {
+        // Can disable xosc
+        xosc_disable();
+    }
+#if 0
+    // Reconfigure uart with new clocks
+    setup_default_uart();
+#endif
+}
+
+// Go to sleep until woken up by the RTC
+void sleep_goto_sleep_until(datetime_t *t, rtc_callback_t callback) {
+    // We should have already called the sleep_run_from_dormant_source function
+    assert(dormant_source_valid(_dormant_source));
+
+    // Turn off all clocks when in sleep mode except for RTC
+    clocks_hw->sleep_en0 = CLOCKS_SLEEP_EN0_CLK_RTC_RTC_BITS;
+    clocks_hw->sleep_en1 = 0x0;
+
+    rtc_set_alarm(t, callback);
+
+    uint save = scb_hw->scr;
+    // Enable deep sleep at the proc
+    scb_hw->scr = save | M0PLUS_SCR_SLEEPDEEP_BITS;
+
+    // Go to sleep
+    __wfi();
+}
+
+static void _go_dormant(void) {
+    assert(dormant_source_valid(_dormant_source));
+
+    if (_dormant_source == DORMANT_SOURCE_XOSC) {
+        xosc_dormant();
+    } else {
+        rosc_set_dormant();
+    }
+}
+
+void sleep_goto_dormant_until_pin(uint gpio_pin, bool edge, bool high) {
+    bool low = !high;
+    bool level = !edge;
+
+    // Configure the appropriate IRQ at IO bank 0
+    assert(gpio_pin < NUM_BANK0_GPIOS);
+
+    uint32_t event = 0;
+
+    if (level && low) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_LEVEL_LOW_BITS;
+    if (level && high) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_LEVEL_HIGH_BITS;
+    if (edge && high) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_EDGE_HIGH_BITS;
+    if (edge && low) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_EDGE_LOW_BITS;
+
+    gpio_set_dormant_irq_enabled(gpio_pin, event, true);
+
+    _go_dormant();
+    // Execution stops here until woken up
+
+    // Clear the irq so we can go back to dormant mode again if we want
+    gpio_acknowledge_irq(gpio_pin, event);
+}
+#endif /* ARDUINO_ARCH_RP2040 */


### PR DESCRIPTION
This is a working example for RP2040. Persistent storage is implemented using https://github.com/vshymanskyy/Preferences and putting a few variables into the .uninitialized_data RAM section. The watchdog scratch register 1 is used for initial initialization after HW reset.
Resuming normal operation after wake-up is possible, but currently does not work presumably due to incorrect restoring of clock configurations. As a workaround, a soft reset is performed after wake-up.